### PR TITLE
Do not use the /tree path in redirects, the container should has a default_url

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -135,7 +135,7 @@ http {
 					ngx.var.server = res.body
 				end
 			}
-			proxy_pass http://$server/container/$3/tree?$query_string;
+			proxy_pass http://$server/container/$workspaceId/?$query_string;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header Host $http_host;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Signed-off-by: Ernesto Cruz <ernesto.cruzoviedo@gmail.com>
reference: http://jupyter-notebook.readthedocs.io/en/latest/config.html