### PR TITLE
Server logs and minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,6 @@ RUN apt-get update \
  && apt-get install -yq --no-install-recommends \
     build-essential \
     git \
-    libffi-dev \
-    libpq-dev \
-    nano \
-    python-pip \
-    python3-dev \
-    python3-pip \
     vim \
     wget \
  && apt-get autoremove \
@@ -33,7 +27,7 @@ RUN apt-get install -y \
     make \
     perl
 
-ENV OPENRESTY_VERSION 1.11.2.2
+ENV OPENRESTY_VERSION 1.11.2.3
 
 RUN echo "==> Downloading OpenResty..." \
  && wget -O /tmp/openresty.tar.gz http://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz \

--- a/nginx.conf
+++ b/nginx.conf
@@ -87,6 +87,31 @@ http {
 			}
 		}
 
+		location ~* /server/logs/(?<serverId>[a-zA-Z0-9-]+) {
+			set $container "";
+			set $url_ips '/server/containerName/$serverId';
+			rewrite_by_lua_block {
+				local res = ngx.location.capture(ngx.var.url_ips)
+				ngx.var.container = res.body
+			}
+			proxy_pass http://logspout/ws-plain/name:$container;
+			proxy_redirect off;
+			proxy_buffering off;
+			proxy_buffer_size  16k;
+			proxy_buffers 16  16k;
+
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection "Upgrade";
+
+			proxy_cache_bypass 1;
+			proxy_no_cache 1;
+		}
+
 		location /socket.io {
 			proxy_pass http://notificationsserver/socket.io;
 			proxy_redirect off;
@@ -147,32 +172,6 @@ http {
 			proxy_set_header Connection "upgrade";
 			proxy_read_timeout 186400;
 		}
-
-		location ~* /server/logs/(?<serverId>[a-zA-Z0-9-]+) {
-			set $container "";
-			set $url_ips '/server/containerName/$serverId';
-			rewrite_by_lua_block {
-				local res = ngx.location.capture(ngx.var.url_ips)
-				ngx.var.container = res.body
-			}
-			proxy_pass http://logspout/ws-plain/name:$container;
-			proxy_redirect off;
-			proxy_buffering off;
-			proxy_buffer_size  16k;
-			proxy_buffers 16  16k;
-
-			proxy_set_header Host $host;
-			proxy_set_header X-Real-IP $remote_addr;
-			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-
-			proxy_http_version 1.1;
-			proxy_set_header Upgrade $http_upgrade;
-			proxy_set_header Connection "Upgrade";
-
-			proxy_cache_bypass 1;
-			proxy_no_cache 1;
-		}
-
 
 		location ~* /container/(?<workspaceId>[a-zA-Z0-9-]+)/api/ {
 			set $server "";

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,14 +5,11 @@ events {
 	worker_connections 2048;
 }
 
+env DOCKER_DOMAIN;
+
 http {
-  include                /usr/local/openresty/nginx/conf/mime.types;
+	include                /usr/local/openresty/nginx/conf/mime.types;
 	default_type           text/html;
-	
-	upstream logspout {
-		ip_hash;
-		server logspout;
-	}
 
 	upstream api {
 		ip_hash;
@@ -38,7 +35,7 @@ http {
 		server_tokens off;
 
 		location /static {
-		    alias /srv/app/static;
+			alias /srv/app/static;
 		}
 
 		location  ~* "/server/ips/(?<serverId>[a-zA-Z0-9-]+)/(?<service>[a-z]+)$" {
@@ -88,13 +85,14 @@ http {
 		}
 
 		location ~* /server/logs/(?<serverId>[a-zA-Z0-9-]+) {
+			set_by_lua $docker_host 'return os.getenv("DOCKER_DOMAIN")';
 			set $container "";
 			set $url_ips '/server/containerName/$serverId';
 			rewrite_by_lua_block {
 				local res = ngx.location.capture(ngx.var.url_ips)
 				ngx.var.container = res.body
 			}
-			proxy_pass http://logspout/ws-plain/name:$container;
+			proxy_pass http://$docker_host/v1.29/containers/$container/attach/ws?logs=0&stream=1&stdout=1&stderr=1;
 			proxy_redirect off;
 			proxy_buffering off;
 			proxy_buffer_size  16k;


### PR DESCRIPTION
Openresty requires now a `DOCKER_DOMAIN` env variable (ex. 172.17.0.1:2375) in order for server logs to work.